### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm i --save node-artifact-api
 import singular methods, or full api as object
 
 ```javascript
-import { getDeck, getSet } from 'node-artifact-api';
+import { decodeDeck, getSet } from 'node-artifact-api';
 
 // OR
 


### PR DESCRIPTION
You can't import getDeck function. I think you mean to add there a decodeDeck function, the getDeck is method of deckApi class that actually do the decoding.